### PR TITLE
Update getWeights

### DIFF
--- a/examples/my_example.py
+++ b/examples/my_example.py
@@ -125,7 +125,7 @@ my_model_my_threshold_pop.record(['v'])
 
 p.run(run_time)
 
-print stdp_connection.getWeights()
+print stdp_connection.get('weight', 'list')
 
 # get v for each example
 v_my_model_pop = my_model_pop.get_data('v')


### PR DESCRIPTION
Doing slides for workshop and noticed this was still using the deprecated version of getting weights