### PR TITLE
Rename of makefiles to no longer use filetype prefixes

### DIFF
--- a/c_models/Makefile
+++ b/c_models/Makefile
@@ -2,13 +2,13 @@ BUILDS = neuron
 DIRS = $(BUILDS:%=src/%)
 
 all: $(DIRS)
-	for d in $(DIRS); do (cd $$d; "$(MAKE)") || exit $$?; done
+	for d in $(DIRS); do $(MAKE) -C $$d || exit $$?; done
 
 %.aplx: %
-	cd $*; "$(MAKE)"
+	$(MAKE) -C $*
 
 %.aplx: neuron/builds/%
-	cd neuron/builds/$*; "$(MAKE)"
+	$(MAKE) -C neuron/builds/$*
 
 clean: $(DIRS)
-	for d in $(DIRS); do (cd $$d; "$(MAKE)" clean) || exit $$?; done
+	for d in $(DIRS); do $(MAKE) -C $$d clean || exit $$?; done

--- a/c_models/src/Makefile.common
+++ b/c_models/src/Makefile.common
@@ -1,11 +1,4 @@
-ifndef NEURAL_MODELLING_DIRS
-    $(error NEURAL_MODELLING_DIRS is not set.  Please define NEURAL_MODELLING_DIRS (possibly by running "source setup" in the neural_modelling folder within the sPyNNaker source folder))
-endif
-
-MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-CURRENT_DIR := $(dir $(MAKEFILE_PATH))
-EXTRA_SRC_DIR := $(abspath $(CURRENT_DIR))
-APP_OUTPUT_DIR := $(abspath $(CURRENT_DIR)../../python_models8/model_binaries/)/
-CFLAGS += -I$(NEURAL_MODELLING_DIRS)/src
-
-include $(NEURAL_MODELLING_DIRS)/src/Makefile.common
+# THIS FILE IS A STUB FOR A RENAMED VERSION
+# IT IS KEPT FOR BACKWARD COMPATIBILITY ONLY
+$(warning inclusion of Makefile.common instead of common.mk)
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common.mk

--- a/c_models/src/common.mk
+++ b/c_models/src/common.mk
@@ -1,0 +1,11 @@
+ifndef NEURAL_MODELLING_DIRS
+    $(error NEURAL_MODELLING_DIRS is not set.  Please define NEURAL_MODELLING_DIRS (possibly by running "source setup" in the neural_modelling folder within the sPyNNaker source folder))
+endif
+
+MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(dir $(MAKEFILE_PATH))
+EXTRA_SRC_DIR := $(abspath $(CURRENT_DIR))
+APP_OUTPUT_DIR := $(abspath $(CURRENT_DIR)../../python_models8/model_binaries/)/
+CFLAGS += -I$(NEURAL_MODELLING_DIRS)/src
+
+include $(NEURAL_MODELLING_DIRS)/src/common.mk

--- a/c_models/src/neuron/Makefile
+++ b/c_models/src/neuron/Makefile
@@ -7,7 +7,7 @@ MODELS = my_model_curr_exp \
 BUILD_DIRS := $(addprefix builds/, $(MODELS))
 
 all: $(BUILD_DIRS)
-	for d in $(BUILD_DIRS); do (cd $$d; "$(MAKE)") || exit $$?; done
+	for d in $(BUILD_DIRS); do $(MAKE) -C $$d || exit $$?; done
 
 clean: $(BUILD_DIRS)
-	for d in $(BUILD_DIRS); do (cd $$d; "$(MAKE)" clean) || exit $$?; done
+	for d in $(BUILD_DIRS); do $(MAKE) -C $$d clean || exit $$?; done

--- a/c_models/src/neuron/builds/Makefile.common
+++ b/c_models/src/neuron/builds/Makefile.common
@@ -1,16 +1,4 @@
-ifndef NEURAL_MODELLING_DIRS
-    $(error NEURAL_MODELLING_DIRS is not set.  Please define NEURAL_MODELLING_DIRS (possibly by running "source setup" in the neural_modelling folder within the sPyNNaker source folder))
-endif
-
-MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
-CURRENT_DIR := $(dir $(MAKEFILE_PATH))
-EXTRA_SRC_DIR := $(abspath $(CURRENT_DIR))/../../
-SOURCE_DIRS += $(EXTRA_SRC_DIR)
-APP_OUTPUT_DIR := $(abspath $(CURRENT_DIR)../../../../python_models8/model_binaries/)/
-CFLAGS += -I$(NEURAL_MODELLING_DIRS)/src
-
-EXTRA_SYNAPSE_TYPE_OBJECTS += 
-                       
-EXTRA_STDP += 
-
-include $(NEURAL_MODELLING_DIRS)/src/neuron/builds/Makefile.common
+# THIS FILE IS A STUB FOR A RENAMED VERSION
+# IT IS KEPT FOR BACKWARD COMPATIBILITY ONLY
+$(warning inclusion of Makefile.common instead of common.mk)
+include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common.mk

--- a/c_models/src/neuron/builds/common.mk
+++ b/c_models/src/neuron/builds/common.mk
@@ -1,0 +1,16 @@
+ifndef NEURAL_MODELLING_DIRS
+    $(error NEURAL_MODELLING_DIRS is not set.  Please define NEURAL_MODELLING_DIRS (possibly by running "source setup" in the neural_modelling folder within the sPyNNaker source folder))
+endif
+
+MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+CURRENT_DIR := $(dir $(MAKEFILE_PATH))
+EXTRA_SRC_DIR := $(abspath $(CURRENT_DIR))/../../
+SOURCE_DIRS += $(EXTRA_SRC_DIR)
+APP_OUTPUT_DIR := $(abspath $(CURRENT_DIR)../../../../python_models8/model_binaries/)/
+CFLAGS += -I$(NEURAL_MODELLING_DIRS)/src
+
+EXTRA_SYNAPSE_TYPE_OBJECTS += 
+                       
+EXTRA_STDP += 
+
+include $(NEURAL_MODELLING_DIRS)/src/neuron/builds/common.mk

--- a/c_models/src/neuron/builds/my_model_curr_exp/Makefile
+++ b/c_models/src/neuron/builds/my_model_curr_exp/Makefile
@@ -8,4 +8,4 @@ THRESHOLD_TYPE_H = $(SOURCE_DIR)/neuron/threshold_types/threshold_type_static.h
 SYNAPSE_TYPE_H = $(SOURCE_DIR)/neuron/synapse_types/synapse_types_exponential_impl.h
 SYNAPSE_DYNAMICS = $(SOURCE_DIR)/neuron/plasticity/synapse_dynamics_static_impl.c
 
-include ../Makefile.common
+include ../common.mk

--- a/c_models/src/neuron/builds/my_model_curr_exp_my_additional_input/Makefile
+++ b/c_models/src/neuron/builds/my_model_curr_exp_my_additional_input/Makefile
@@ -9,4 +9,4 @@ THRESHOLD_TYPE_H = $(SOURCE_DIR)/neuron/threshold_types/threshold_type_static.h
 SYNAPSE_TYPE_H = $(SOURCE_DIR)/neuron/synapse_types/synapse_types_exponential_impl.h
 SYNAPSE_DYNAMICS = $(SOURCE_DIR)/neuron/plasticity/synapse_dynamics_static_impl.c
 
-include ../Makefile.common
+include ../common.mk

--- a/c_models/src/neuron/builds/my_model_curr_exp_my_threshold/Makefile
+++ b/c_models/src/neuron/builds/my_model_curr_exp_my_threshold/Makefile
@@ -8,4 +8,4 @@ THRESHOLD_TYPE_H = $(EXTRA_SRC_DIR)/neuron/threshold_types/my_threshold_type.h
 SYNAPSE_TYPE_H = $(SOURCE_DIR)/neuron/synapse_types/synapse_types_exponential_impl.h
 SYNAPSE_DYNAMICS = $(SOURCE_DIR)/neuron/plasticity/synapse_dynamics_static_impl.c
 
-include ../Makefile.common
+include ../common.mk

--- a/c_models/src/neuron/builds/my_model_curr_exp_stdp_mad_my_timing_my_weight/Makefile
+++ b/c_models/src/neuron/builds/my_model_curr_exp_stdp_mad_my_timing_my_weight/Makefile
@@ -12,4 +12,4 @@ TIMING_DEPENDENCE_H = $(EXTRA_SRC_DIR)/neuron/plasticity/stdp/timing_dependence/
 WEIGHT_DEPENDENCE = $(EXTRA_SRC_DIR)/neuron/plasticity/stdp/weight_dependence/my_weight_impl.c
 WEIGHT_DEPENDENCE_H = $(EXTRA_SRC_DIR)/neuron/plasticity/stdp/weight_dependence/my_weight_impl.h
 
-include ../Makefile.common
+include ../common.mk

--- a/c_models/src/neuron/builds/my_model_curr_my_synapse_type/Makefile
+++ b/c_models/src/neuron/builds/my_model_curr_my_synapse_type/Makefile
@@ -8,4 +8,4 @@ THRESHOLD_TYPE_H = $(SOURCE_DIR)/neuron/threshold_types/threshold_type_static.h
 SYNAPSE_TYPE_H = $(EXTRA_SRC_DIR)/neuron/synapse_types/synapse_types_my_impl.h
 SYNAPSE_DYNAMICS = $(SOURCE_DIR)/neuron/plasticity/synapse_dynamics_static_impl.c
 
-include ../Makefile.common
+include ../common.mk


### PR DESCRIPTION
Leaves stubs in place for old code. Those stubs issue warnings (which should be harmless but noticeable) if used.