### PR TITLE
A more compact way of handling the defaults dicts

### DIFF
--- a/python_models8/model_data_holders/my_model_curr_exp_data_holder.py
+++ b/python_models8/model_data_holders/my_model_curr_exp_data_holder.py
@@ -5,25 +5,27 @@ from spynnaker8.utilities import DataHolder
 from python_models8.neuron.builds.my_model_curr_exp \
     import MyModelCurrExpBase as MyCurrExp
 
+# Merge the defaults together
+_defaults = dict(Vertex.none_pynn_default_parameters)
+_defaults.update(MyCurrExp.non_pynn_default_parameters)
+_defaults.update(MyCurrExp.default_parameters)
+
 
 class MyModelCurrExpDataHolder(DataHolder):
     def __init__(
-            self, spikes_per_second=Vertex.none_pynn_default_parameters[
-                'spikes_per_second'],
-            ring_buffer_sigma=Vertex.none_pynn_default_parameters[
-                'ring_buffer_sigma'],
-            incoming_spike_buffer_size=Vertex.none_pynn_default_parameters[
-                'incoming_spike_buffer_size'],
-            constraints=Vertex.none_pynn_default_parameters['constraints'],
-            label=Vertex.none_pynn_default_parameters['label'],
-            v_init=MyCurrExp.non_pynn_default_parameters['v_init'],
-            v_thresh=MyCurrExp.default_parameters['v_thresh'],
-            tau_syn_E=MyCurrExp.default_parameters['tau_syn_E'],
-            tau_syn_I=MyCurrExp.default_parameters['tau_syn_I'],
-            isyn_exc=MyCurrExp.default_parameters['isyn_exc'],
-            isyn_inh=MyCurrExp.default_parameters['isyn_inh'],
-            my_parameter=MyCurrExp.default_parameters['my_parameter'],
-            i_offset=MyCurrExp.default_parameters['i_offset']):
+            self, spikes_per_second=_defaults['spikes_per_second'],
+            ring_buffer_sigma=_defaults['ring_buffer_sigma'],
+            incoming_spike_buffer_size=_defaults['incoming_spike_buffer_size'],
+            constraints=_defaults['constraints'],
+            label=_defaults['label'],
+            v_init=_defaults['v_init'],
+            v_thresh=_defaults['v_thresh'],
+            tau_syn_E=_defaults['tau_syn_E'],
+            tau_syn_I=_defaults['tau_syn_I'],
+            isyn_exc=_defaults['isyn_exc'],
+            isyn_inh=_defaults['isyn_inh'],
+            my_parameter=_defaults['my_parameter'],
+            i_offset=_defaults['i_offset']):
         super(MyModelCurrExpDataHolder, self).__init__({
             'spikes_per_second': spikes_per_second,
             'ring_buffer_sigma': ring_buffer_sigma,

--- a/python_models8/model_data_holders/my_model_curr_exp_my_additional_input_data_holder.py
+++ b/python_models8/model_data_holders/my_model_curr_exp_my_additional_input_data_holder.py
@@ -5,27 +5,29 @@ from spynnaker8.utilities import DataHolder
 from python_models8.neuron.builds.my_model_curr_exp_my_additional_input \
     import MyModelCurrExpMyAdditionalInputBase as MyAdditionalInput
 
+# Merge the defaults together
+_defaults = dict(Vertex.none_pynn_default_parameters)
+_defaults.update(MyAdditionalInput.non_pynn_default_parameters)
+_defaults.update(MyAdditionalInput.default_parameters)
+
 
 class MyModelCurrExpMyAdditionalInputDataHolder(DataHolder):
     def __init__(
-            self, spikes_per_second=Vertex.none_pynn_default_parameters[
-                'spikes_per_second'],
-            ring_buffer_sigma=Vertex.none_pynn_default_parameters[
-                'ring_buffer_sigma'],
-            incoming_spike_buffer_size=Vertex.none_pynn_default_parameters[
-                'incoming_spike_buffer_size'],
-            constraints=Vertex.none_pynn_default_parameters['constraints'],
-            label=Vertex.none_pynn_default_parameters['label'],
-            v_init=MyAdditionalInput.non_pynn_default_parameters['v_init'],
-            v_thresh=MyAdditionalInput.default_parameters['v_thresh'],
-            tau_syn_E=MyAdditionalInput.default_parameters['tau_syn_E'],
-            tau_syn_I=MyAdditionalInput.default_parameters['tau_syn_I'],
-            isyn_exc=MyAdditionalInput.default_parameters['isyn_exc'],
-            isyn_inh=MyAdditionalInput.default_parameters['isyn_inh'],
-            my_additional_input_parameter=MyAdditionalInput.default_parameters[
+            self, spikes_per_second=_defaults['spikes_per_second'],
+            ring_buffer_sigma=_defaults['ring_buffer_sigma'],
+            incoming_spike_buffer_size=_defaults['incoming_spike_buffer_size'],
+            constraints=_defaults['constraints'],
+            label=_defaults['label'],
+            v_init=_defaults['v_init'],
+            v_thresh=_defaults['v_thresh'],
+            tau_syn_E=_defaults['tau_syn_E'],
+            tau_syn_I=_defaults['tau_syn_I'],
+            isyn_exc=_defaults['isyn_exc'],
+            isyn_inh=_defaults['isyn_inh'],
+            my_additional_input_parameter=_defaults[
                 'my_additional_input_parameter'],
-            my_parameter=MyAdditionalInput.default_parameters['my_parameter'],
-            i_offset=MyAdditionalInput.default_parameters['i_offset']):
+            my_parameter=_defaults['my_parameter'],
+            i_offset=_defaults['i_offset']):
         super(MyModelCurrExpMyAdditionalInputDataHolder, self).__init__({
             'spikes_per_second': spikes_per_second,
             'ring_buffer_sigma': ring_buffer_sigma,

--- a/python_models8/model_data_holders/my_model_curr_exp_my_threshold_data_holder.py
+++ b/python_models8/model_data_holders/my_model_curr_exp_my_threshold_data_holder.py
@@ -5,27 +5,28 @@ from spynnaker8.utilities import DataHolder
 from python_models8.neuron.builds.my_model_curr_exp_my_threshold \
     import MyModelCurrExpMyThresholdBase as MyThreshold
 
+# Merge the defaults together
+_defaults = dict(Vertex.none_pynn_default_parameters)
+_defaults.update(MyThreshold.non_pynn_default_parameters)
+_defaults.update(MyThreshold.default_parameters)
+
 
 class MyModelCurrExpMyThresholdDataHolder(DataHolder):
     def __init__(
-            self, spikes_per_second=Vertex.none_pynn_default_parameters[
-                'spikes_per_second'],
-            ring_buffer_sigma=Vertex.none_pynn_default_parameters[
-                'ring_buffer_sigma'],
-            incoming_spike_buffer_size=Vertex.none_pynn_default_parameters[
-                'incoming_spike_buffer_size'],
-            constraints=Vertex.none_pynn_default_parameters['constraints'],
-            label=Vertex.none_pynn_default_parameters['label'],
-            v_init=MyThreshold.non_pynn_default_parameters['v_init'],
-            tau_syn_E=MyThreshold.default_parameters['tau_syn_E'],
-            tau_syn_I=MyThreshold.default_parameters['tau_syn_I'],
-            isyn_exc=MyThreshold.default_parameters['isyn_exc'],
-            isyn_inh=MyThreshold.default_parameters['isyn_inh'],
-            my_threshold_parameter=MyThreshold.default_parameters[
-                'my_threshold_parameter'],
-            threshold_value=MyThreshold.default_parameters['threshold_value'],
-            my_parameter=MyThreshold.default_parameters['my_parameter'],
-            i_offset=MyThreshold.default_parameters['i_offset']):
+            self, spikes_per_second=_defaults['spikes_per_second'],
+            ring_buffer_sigma=_defaults['ring_buffer_sigma'],
+            incoming_spike_buffer_size=_defaults['incoming_spike_buffer_size'],
+            constraints=_defaults['constraints'],
+            label=_defaults['label'],
+            v_init=_defaults['v_init'],
+            tau_syn_E=_defaults['tau_syn_E'],
+            tau_syn_I=_defaults['tau_syn_I'],
+            isyn_exc=_defaults['isyn_exc'],
+            isyn_inh=_defaults['isyn_inh'],
+            my_threshold_parameter=_defaults['my_threshold_parameter'],
+            threshold_value=_defaults['threshold_value'],
+            my_parameter=_defaults['my_parameter'],
+            i_offset=_defaults['i_offset']):
         super(MyModelCurrExpMyThresholdDataHolder, self).__init__({
             'spikes_per_second': spikes_per_second,
             'ring_buffer_sigma': ring_buffer_sigma,

--- a/python_models8/model_data_holders/my_model_curr_my_synapse_type_data_holder.py
+++ b/python_models8/model_data_holders/my_model_curr_my_synapse_type_data_holder.py
@@ -5,27 +5,27 @@ from spynnaker8.utilities import DataHolder
 from python_models8.neuron.builds.my_model_curr_my_synapse_type \
     import MyModelCurrMySynapseTypeBase as MySynapseType
 
+# Merge the defaults together
+_defaults = dict(Vertex.none_pynn_default_parameters)
+_defaults.update(MySynapseType.non_pynn_default_parameters)
+_defaults.update(MySynapseType.default_parameters)
+
 
 class MyModelCurrMySynapseTypeDataHolder(DataHolder):
     def __init__(
-            self, spikes_per_second=Vertex.none_pynn_default_parameters[
-                'spikes_per_second'],
-            ring_buffer_sigma=Vertex.none_pynn_default_parameters[
-                'ring_buffer_sigma'],
-            incoming_spike_buffer_size=Vertex.none_pynn_default_parameters[
-                'incoming_spike_buffer_size'],
-            constraints=Vertex.none_pynn_default_parameters['constraints'],
-            label=Vertex.none_pynn_default_parameters['label'],
-            v_init=MySynapseType.non_pynn_default_parameters['v_init'],
-            v_thresh=MySynapseType.default_parameters['v_thresh'],
-            my_ex_synapse_parameter=MySynapseType.default_parameters[
-                'my_ex_synapse_parameter'],
-            my_in_synapse_parameter=MySynapseType.default_parameters[
-                'my_in_synapse_parameter'],
-            my_exc_init=MySynapseType.default_parameters['my_exc_init'],
-            my_inh_init=MySynapseType.default_parameters['my_inh_init'],
-            my_parameter=MySynapseType.default_parameters['my_parameter'],
-            i_offset=MySynapseType.default_parameters['i_offset']):
+            self, spikes_per_second=_defaults['spikes_per_second'],
+            ring_buffer_sigma=_defaults['ring_buffer_sigma'],
+            incoming_spike_buffer_size=_defaults['incoming_spike_buffer_size'],
+            constraints=_defaults['constraints'],
+            label=_defaults['label'],
+            v_init=_defaults['v_init'],
+            v_thresh=_defaults['v_thresh'],
+            my_ex_synapse_parameter=_defaults['my_ex_synapse_parameter'],
+            my_in_synapse_parameter=_defaults['my_in_synapse_parameter'],
+            my_exc_init=_defaults['my_exc_init'],
+            my_inh_init=_defaults['my_inh_init'],
+            my_parameter=_defaults['my_parameter'],
+            i_offset=_defaults['i_offset']):
         super(MyModelCurrMySynapseTypeDataHolder, self).__init__({
             'spikes_per_second': spikes_per_second,
             'ring_buffer_sigma': ring_buffer_sigma,

--- a/python_models8/neuron/builds/my_model_curr_exp.py
+++ b/python_models8/neuron/builds/my_model_curr_exp.py
@@ -60,37 +60,37 @@ class MyModelCurrExpBase(AbstractPopulationVertex):
 
     non_pynn_default_parameters = {'v_init': None}
 
+    # Merge the three dictionaries of defaults for convenience    
+    _defaults = dict(AbstractPopulationVertex.none_pynn_default_parameters)
+    _defaults.update(default_parameters)
+    _defaults.update(non_pynn_default_parameters)
+
     def __init__(
-            self, n_neurons, spikes_per_second=AbstractPopulationVertex.
-            none_pynn_default_parameters['spikes_per_second'],
-            ring_buffer_sigma=AbstractPopulationVertex.
-            none_pynn_default_parameters['ring_buffer_sigma'],
-            incoming_spike_buffer_size=AbstractPopulationVertex.
-            none_pynn_default_parameters['incoming_spike_buffer_size'],
-            constraints=AbstractPopulationVertex.none_pynn_default_parameters[
-                'constraints'],
-            label=AbstractPopulationVertex.none_pynn_default_parameters[
-                'label'],
+            self, n_neurons, spikes_per_second=_defaults['spikes_per_second'],
+            ring_buffer_sigma=_defaults['ring_buffer_sigma'],
+            incoming_spike_buffer_size=_defaults['incoming_spike_buffer_size'],
+            constraints=_defaults['constraints'],
+            label=_defaults['label'],
 
             # TODO: neuron model parameters (add / remove as required)
             # neuron model parameters
-            my_parameter=default_parameters['my_parameter'],
-            i_offset=default_parameters['i_offset'],
+            my_parameter=_defaults['my_parameter'],
+            i_offset=_defaults['i_offset'],
 
             # TODO: threshold types parameters (add / remove as required)
             # threshold types parameters
-            v_thresh=default_parameters['v_thresh'],
+            v_thresh=_defaults['v_thresh'],
 
             # TODO: synapse type parameters (add /remove as required)
             # synapse type parameters
-            tau_syn_E=default_parameters['tau_syn_E'],
-            tau_syn_I=default_parameters['tau_syn_I'],
-            isyn_exc=default_parameters['isyn_exc'],
-            isyn_inh=default_parameters['isyn_inh'],
+            tau_syn_E=_defaults['tau_syn_E'],
+            tau_syn_I=_defaults['tau_syn_I'],
+            isyn_exc=_defaults['isyn_exc'],
+            isyn_inh=_defaults['isyn_inh'],
 
             # TODO: Optionally, you can add initial values for the state
             # variables; this is not technically done in PyNN
-            v_init=non_pynn_default_parameters['v_init']):
+            v_init=_defaults['v_init']):
 
         # TODO: create your neuron model class (change if required)
         # create your neuron model class
@@ -118,14 +118,13 @@ class MyModelCurrExpBase(AbstractPopulationVertex):
         # the AbstractPopulationVertex
         super(MyModelCurrExpBase, self).__init__(
             # standard inputs, do not need to change.
-            n_neurons=n_neurons, label=label,
+            n_neurons=n_neurons, label=label, constraints=constraints,
             spikes_per_second=spikes_per_second,
             ring_buffer_sigma=ring_buffer_sigma,
             incoming_spike_buffer_size=incoming_spike_buffer_size,
 
             # TODO: Ensure the correct class is used below
-            max_atoms_per_core=(
-                MyModelCurrExpBase._model_based_max_atoms_per_core),
+            max_atoms_per_core=self.get_max_atoms_per_core(),
 
             # These are the various model types
             neuron_model=neuron_model, input_type=input_type,

--- a/python_models8/neuron/builds/my_model_curr_exp.py
+++ b/python_models8/neuron/builds/my_model_curr_exp.py
@@ -60,7 +60,7 @@ class MyModelCurrExpBase(AbstractPopulationVertex):
 
     non_pynn_default_parameters = {'v_init': None}
 
-    # Merge the three dictionaries of defaults for convenience    
+    # Merge the three dictionaries of defaults for convenience
     _defaults = dict(AbstractPopulationVertex.none_pynn_default_parameters)
     _defaults.update(default_parameters)
     _defaults.update(non_pynn_default_parameters)

--- a/python_models8/neuron/builds/my_model_curr_exp_my_additional_input.py
+++ b/python_models8/neuron/builds/my_model_curr_exp_my_additional_input.py
@@ -26,7 +26,7 @@ class MyModelCurrExpMyAdditionalInputBase(AbstractPopulationVertex):
 
     non_pynn_default_parameters = {'v_init': None}
 
-    # Merge the three dictionaries of defaults for convenience    
+    # Merge the three dictionaries of defaults for convenience
     _defaults = dict(AbstractPopulationVertex.none_pynn_default_parameters)
     _defaults.update(default_parameters)
     _defaults.update(non_pynn_default_parameters)

--- a/python_models8/neuron/builds/my_model_curr_exp_my_additional_input.py
+++ b/python_models8/neuron/builds/my_model_curr_exp_my_additional_input.py
@@ -26,29 +26,38 @@ class MyModelCurrExpMyAdditionalInputBase(AbstractPopulationVertex):
 
     non_pynn_default_parameters = {'v_init': None}
 
+    # Merge the three dictionaries of defaults for convenience    
+    _defaults = dict(AbstractPopulationVertex.none_pynn_default_parameters)
+    _defaults.update(default_parameters)
+    _defaults.update(non_pynn_default_parameters)
+
     def __init__(
-            self, n_neurons, spikes_per_second=None, ring_buffer_sigma=None,
-            incoming_spike_buffer_size=None, constraints=None, label=None,
+            self, n_neurons,
+            spikes_per_second=_defaults['spikes_per_second'],
+            ring_buffer_sigma=_defaults['ring_buffer_sigma'],
+            incoming_spike_buffer_size=_defaults['incoming_spike_buffer_size'],
+            constraints=_defaults['constraints'],
+            label=_defaults['label'],
 
             # neuron model parameters
-            my_parameter=default_parameters['my_parameter'],
-            i_offset=default_parameters['i_offset'],
+            my_parameter=_defaults['my_parameter'],
+            i_offset=_defaults['i_offset'],
 
             # threshold types parameters
-            v_thresh=default_parameters['v_thresh'],
+            v_thresh=_defaults['v_thresh'],
 
             # synapse type parameters
-            tau_syn_E=default_parameters['tau_syn_E'],
-            tau_syn_I=default_parameters['tau_syn_I'],
-            isyn_exc=default_parameters['isyn_exc'],
-            isyn_inh=default_parameters['isyn_inh'],
+            tau_syn_E=_defaults['tau_syn_E'],
+            tau_syn_I=_defaults['tau_syn_I'],
+            isyn_exc=_defaults['isyn_exc'],
+            isyn_inh=_defaults['isyn_inh'],
 
             # additional input parameter
             my_additional_input_parameter=(
-                default_parameters['my_additional_input_parameter']),
+                _defaults['my_additional_input_parameter']),
 
             # state variables
-            v_init=None):
+            v_init=_defaults['v_init']):
 
         # create neuron model class
         neuron_model = MyNeuronModel(
@@ -70,18 +79,16 @@ class MyModelCurrExpMyAdditionalInputBase(AbstractPopulationVertex):
             n_neurons, my_additional_input_parameter)
 
         # instantiate the sPyNNaker system by initialising
-        #  the AbstractPopulationVertex
+        # the AbstractPopulationVertex
         super(MyModelCurrExpMyAdditionalInputBase, self).__init__(
 
             # standard inputs, do not need to change.
-            n_neurons=n_neurons, label=label,
+            n_neurons=n_neurons, label=label, constraints=constraints,
             spikes_per_second=spikes_per_second,
             ring_buffer_sigma=ring_buffer_sigma,
             incoming_spike_buffer_size=incoming_spike_buffer_size,
 
-            max_atoms_per_core=(
-                MyModelCurrExpMyAdditionalInputBase.
-                _model_based_max_atoms_per_core),
+            max_atoms_per_core=self.get_max_atoms_per_core(),
 
             # the various model types
             neuron_model=neuron_model, input_type=input_type,

--- a/python_models8/neuron/builds/my_model_curr_exp_my_threshold.py
+++ b/python_models8/neuron/builds/my_model_curr_exp_my_threshold.py
@@ -23,38 +23,37 @@ class MyModelCurrExpMyThresholdBase(AbstractPopulationVertex):
         'i_offset': 0, 'my_parameter': -70.0,
         'my_threshold_parameter': 0.5,
         'threshold_value': -10.0}
-
     non_pynn_default_parameters = {'v_init': None}
 
+    # Merge the three dictionaries of defaults for convenience    
+    _defaults = dict(AbstractPopulationVertex.none_pynn_default_parameters)
+    _defaults.update(default_parameters)
+    _defaults.update(non_pynn_default_parameters)
+
     def __init__(
-            self, n_neurons, spikes_per_second=AbstractPopulationVertex.
-            none_pynn_default_parameters['spikes_per_second'],
-            ring_buffer_sigma=AbstractPopulationVertex.
-            none_pynn_default_parameters['ring_buffer_sigma'],
-            incoming_spike_buffer_size=AbstractPopulationVertex.
-            none_pynn_default_parameters['incoming_spike_buffer_size'],
-            constraints=AbstractPopulationVertex.none_pynn_default_parameters[
-                'constraints'],
-            label=AbstractPopulationVertex.none_pynn_default_parameters[
-                'label'],
+            self, n_neurons,
+            spikes_per_second=_defaults['spikes_per_second'],
+            ring_buffer_sigma=_defaults['ring_buffer_sigma'],
+            incoming_spike_buffer_size=_defaults['incoming_spike_buffer_size'],
+            constraints=_defaults['constraints'],
+            label=_defaults['label'],
 
             # neuron model parameters
-            my_parameter=default_parameters['my_parameter'],
-            i_offset=default_parameters['i_offset'],
+            my_parameter=_defaults['my_parameter'],
+            i_offset=_defaults['i_offset'],
 
             # threshold types parameters
-            my_threshold_parameter=(
-                default_parameters['my_threshold_parameter']),
-            threshold_value=default_parameters['threshold_value'],
+            my_threshold_parameter=_defaults['my_threshold_parameter'],
+            threshold_value=_defaults['threshold_value'],
 
             # synapse type parameters
-            tau_syn_E=default_parameters['tau_syn_E'],
-            tau_syn_I=default_parameters['tau_syn_I'],
-            isyn_exc=default_parameters['isyn_exc'],
-            isyn_inh=default_parameters['isyn_inh'],
+            tau_syn_E=_defaults['tau_syn_E'],
+            tau_syn_I=_defaults['tau_syn_I'],
+            isyn_exc=_defaults['isyn_exc'],
+            isyn_inh=_defaults['isyn_inh'],
 
             # state variables
-            v_init=None):
+            v_init=_defaults['v_init']):
 
         # create neuron model class
         neuron_model = MyNeuronModel(
@@ -79,13 +78,12 @@ class MyModelCurrExpMyThresholdBase(AbstractPopulationVertex):
         super(MyModelCurrExpMyThresholdBase, self).__init__(
 
             # standard inputs, do not need to change.
-            n_neurons=n_neurons, label=label,
+            n_neurons=n_neurons, label=label, constraints=constraints,
             spikes_per_second=spikes_per_second,
             ring_buffer_sigma=ring_buffer_sigma,
             incoming_spike_buffer_size=incoming_spike_buffer_size,
 
-            max_atoms_per_core=(
-                MyModelCurrExpMyThresholdBase._model_based_max_atoms_per_core),
+            max_atoms_per_core=self.get_max_atoms_per_core(),
 
             # the various model types
             neuron_model=neuron_model, input_type=input_type,
@@ -100,7 +98,6 @@ class MyModelCurrExpMyThresholdBase(AbstractPopulationVertex):
 
     @staticmethod
     def get_max_atoms_per_core():
-
         return MyModelCurrExpMyThresholdBase._model_based_max_atoms_per_core
 
     @staticmethod

--- a/python_models8/neuron/builds/my_model_curr_exp_my_threshold.py
+++ b/python_models8/neuron/builds/my_model_curr_exp_my_threshold.py
@@ -25,7 +25,7 @@ class MyModelCurrExpMyThresholdBase(AbstractPopulationVertex):
         'threshold_value': -10.0}
     non_pynn_default_parameters = {'v_init': None}
 
-    # Merge the three dictionaries of defaults for convenience    
+    # Merge the three dictionaries of defaults for convenience
     _defaults = dict(AbstractPopulationVertex.none_pynn_default_parameters)
     _defaults.update(default_parameters)
     _defaults.update(non_pynn_default_parameters)

--- a/python_models8/neuron/builds/my_model_curr_my_synapse_type.py
+++ b/python_models8/neuron/builds/my_model_curr_my_synapse_type.py
@@ -24,37 +24,33 @@ class MyModelCurrMySynapseTypeBase(AbstractPopulationVertex):
 
     non_pynn_default_parameters = {'v_init': None}
 
+    # Merge the three dictionaries of defaults for convenience    
+    _defaults = dict(AbstractPopulationVertex.none_pynn_default_parameters)
+    _defaults.update(default_parameters)
+    _defaults.update(non_pynn_default_parameters)
+
     def __init__(
-            self, n_neurons, spikes_per_second=AbstractPopulationVertex.
-            none_pynn_default_parameters['spikes_per_second'],
-            ring_buffer_sigma=AbstractPopulationVertex.
-            none_pynn_default_parameters['ring_buffer_sigma'],
-            incoming_spike_buffer_size=AbstractPopulationVertex.
-            none_pynn_default_parameters['incoming_spike_buffer_size'],
-            constraints=AbstractPopulationVertex.none_pynn_default_parameters[
-                'constraints'],
-            label=AbstractPopulationVertex.none_pynn_default_parameters[
-                'label'],
+            self, n_neurons, spikes_per_second=_defaults['spikes_per_second'],
+            ring_buffer_sigma=_defaults['ring_buffer_sigma'],
+            incoming_spike_buffer_size=_defaults['incoming_spike_buffer_size'],
+            constraints=_defaults['constraints'],
+            label=_defaults['label'],
 
             # neuron model parameters
-            my_parameter=default_parameters['my_parameter'],
-            i_offset=default_parameters['i_offset'],
+            my_parameter=_defaults['my_parameter'],
+            i_offset=_defaults['i_offset'],
 
             # threshold types parameters
-            v_thresh=default_parameters['v_thresh'],
+            v_thresh=_defaults['v_thresh'],
 
             # synapse type parameters
-            my_ex_synapse_parameter=default_parameters[
-                'my_ex_synapse_parameter'],
-            my_in_synapse_parameter=default_parameters[
-                'my_in_synapse_parameter'],
-            my_exc_init=default_parameters[
-                'my_exc_init'],
-            my_inh_init=default_parameters[
-                'my_inh_init'],
+            my_ex_synapse_parameter=_defaults['my_ex_synapse_parameter'],
+            my_in_synapse_parameter=_defaults['my_in_synapse_parameter'],
+            my_exc_init=_defaults['my_exc_init'],
+            my_inh_init=_defaults['my_inh_init'],
 
             # state variables
-            v_init=non_pynn_default_parameters['v_init']):
+            v_init=_defaults['v_init']):
 
         # create neuron model class
         neuron_model = MyNeuronModel(
@@ -78,13 +74,12 @@ class MyModelCurrMySynapseTypeBase(AbstractPopulationVertex):
         # the AbstractPopulationVertex
         super(MyModelCurrMySynapseTypeBase, self).__init__(
             # standard inputs, do not need to change.
-            n_neurons=n_neurons, label=label,
+            n_neurons=n_neurons, label=label, constraints=constraints,
             spikes_per_second=spikes_per_second,
             ring_buffer_sigma=ring_buffer_sigma,
             incoming_spike_buffer_size=incoming_spike_buffer_size,
 
-            max_atoms_per_core=(
-                MyModelCurrMySynapseTypeBase._model_based_max_atoms_per_core),
+            max_atoms_per_core=self.get_max_atoms_per_core(),
 
             # the various model types
             neuron_model=neuron_model, input_type=input_type,

--- a/python_models8/neuron/builds/my_model_curr_my_synapse_type.py
+++ b/python_models8/neuron/builds/my_model_curr_my_synapse_type.py
@@ -24,7 +24,7 @@ class MyModelCurrMySynapseTypeBase(AbstractPopulationVertex):
 
     non_pynn_default_parameters = {'v_init': None}
 
-    # Merge the three dictionaries of defaults for convenience    
+    # Merge the three dictionaries of defaults for convenience
     _defaults = dict(AbstractPopulationVertex.none_pynn_default_parameters)
     _defaults.update(default_parameters)
     _defaults.update(non_pynn_default_parameters)


### PR DESCRIPTION
This is a way to make the access to defaults a lot clearer. Well I think it is clearer.

Essentially, it takes the various places that define defaults and merges them together into one dict (in a variable that is intended to be not used outside the class) that it then does the _real_ lookup from.

***Please consider this before merging [the lint branch](https://github.com/SpiNNakerManchester/sPyNNaker8NewModelTemplate/pull/14) which this is branched off of.***