### PR TITLE
Delete two unneeded files that nothing uses

### DIFF
--- a/c_models/src/Makefile.common
+++ b/c_models/src/Makefile.common
@@ -1,4 +1,0 @@
-# THIS FILE IS A STUB FOR A RENAMED VERSION
-# IT IS KEPT FOR BACKWARD COMPATIBILITY ONLY
-$(warning inclusion of Makefile.common instead of common.mk)
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common.mk

--- a/c_models/src/my_models/builds/Makefile.common
+++ b/c_models/src/my_models/builds/Makefile.common
@@ -1,4 +1,0 @@
-# THIS FILE IS A STUB FOR A RENAMED VERSION
-# IT IS KEPT FOR BACKWARD COMPATIBILITY ONLY
-$(warning inclusion of Makefile.common instead of common.mk)
-include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common.mk


### PR DESCRIPTION
No point *at all* in promoting old practices for new work.

These old files also did nothing but issue warnings and include other files. In one case, the file it wanted to include didn't exist.