### PR TITLE
Update to use function argument rather than global define

### DIFF
--- a/c_models/src/my_models/plasticity/stdp/weight_dependence/my_weight_impl.c
+++ b/c_models/src/my_models/plasticity/stdp/weight_dependence/my_weight_impl.c
@@ -21,7 +21,7 @@ address_t weight_initialise(
         return NULL;
     }
     int32_t *plasticity_word = (int32_t*) address;
-    for (uint32_t s = 0; s < SYNAPSE_TYPE_COUNT; s++) {
+    for (uint32_t s = 0; s < n_synapse_types; s++) {
         plasticity_weight_region_data[s].min_weight = *plasticity_word++;
         plasticity_weight_region_data[s].max_weight = *plasticity_word++;
         plasticity_weight_region_data[s].my_parameter = *plasticity_word++;


### PR DESCRIPTION
Update required due to change in makefiles at https://github.com/SpiNNakerManchester/sPyNNaker/pull/595 - not sure why this was using a global define rather than the function argument, so probably good that we caught this.