### PR TITLE
Upgrade Travis Ubuntu distribution to bionic (18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 python:
   - 2.7
   - 3.6
-dist: trusty
+dist: bionic
 matrix:
   include:
     - python: 3.7
-      dist: xenial
+      dist: bionic
       sudo: true
 cache: pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,8 @@ language: python
 python:
   - 2.7
   - 3.6
+  - 3.7
 dist: focal
-matrix:
-  include:
-    - python: 3.7
-      dist: focal
-      sudo: true
 cache: pip
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 python:
   - 2.7
   - 3.6
-dist: bionic
+dist: focal
 matrix:
   include:
     - python: 3.7
-      dist: bionic
+      dist: focal
       sudo: true
 cache: pip
 


### PR DESCRIPTION
Upgrading Travis Ubuntu distribution to 18.04 (bionic) to help us with binaries that are close to the ITCM limit.

See https://github.com/orgs/SpiNNakerManchester/projects/32 for full list of PRs.