### PR TITLE
remove warning for conversion from const to non-const

### DIFF
--- a/c_models/src/my_models/input_types/my_input_type.h
+++ b/c_models/src/my_models/input_types/my_input_type.h
@@ -30,9 +30,8 @@ static inline void _input_type_set_multiplicator_value(
 }
 
 static inline input_t *input_type_get_input_value(
-        input_t *restrict value, const input_type_t *input_type,
+        input_t *restrict value, input_type_t *input_type,
         uint16_t num_receptors) {
-    use(input_type);
     input_t total = 0.0;
     for (uint32_t i = 0; i < num_receptors; i++) {
         total += value[i];


### PR DESCRIPTION
This particular example was giving compiler warnings for conversion from const to non-const; fixed by switching the function in the input_type.h to non-const.  

Merge at same time as https://github.com/SpiNNakerManchester/sPyNNaker/pull/961