### PR TITLE
Stop passing config values through the simulator

### DIFF
--- a/python_models8/neuron/plasticity/stdp/timing_dependence/my_timing_dependence.py
+++ b/python_models8/neuron/plasticity/stdp/timing_dependence/my_timing_dependence.py
@@ -101,7 +101,7 @@ class MyTimingDependence(AbstractTimingDependence):
         return 1
 
     @overrides(AbstractTimingDependence.write_parameters)
-    def write_parameters(self, spec, machine_time_step, weight_scales):
+    def write_parameters(self, spec, weight_scales):
         # TODO: update to write the parameters
         spec.write_value(
             self._my_potentiation_parameter, data_type=DataType.S1615)

--- a/python_models8/neuron/plasticity/stdp/weight_dependence/my_weight_dependence.py
+++ b/python_models8/neuron/plasticity/stdp/weight_dependence/my_weight_dependence.py
@@ -87,7 +87,7 @@ class MyWeightDependence(AbstractHasAPlusAMinus, AbstractWeightDependence):
 
     @overrides(AbstractWeightDependence.write_parameters)
     def write_parameters(
-            self, spec, machine_time_step, weight_scales, n_weight_terms):
+            self, spec, weight_scales, n_weight_terms):
         # TODO: update to write the parameters
         # Loop through each synapse type's weight scale
         for w in weight_scales:


### PR DESCRIPTION
part of SpiNNakerManchester/SpiNNFrontEndCommon#792

removed parameteres from the api.

If needed use
get_config_int("Machine", "machine_time_step")