### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]


### PR DESCRIPTION
Drop python 3.6 as described in https://github.com/SpiNNakerManchester/SupportScripts/pull/43